### PR TITLE
updated centos iso url

### DIFF
--- a/oracle.json
+++ b/oracle.json
@@ -32,7 +32,7 @@
       "http_directory": "http",
       "iso_checksum": "88c0437f0a14c6e2c94426df9d43cd67",
       "iso_checksum_type": "md5",
-      "iso_url": "http://mirror.symnds.com/CentOS/7.2.1511/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso",
+      "iso_url": "https://buildlogs.centos.org/rolling/7/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso",
       "ssh_username": "veewee",
       "ssh_password": "veewee",
       "ssh_port": 22,


### PR DESCRIPTION
Current iso url doesn't work so replaced it with one which does work.